### PR TITLE
Add autoload for Custom

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -801,6 +801,9 @@ background color that is barely perceptible."
                              :background "#FFF9C4")))) ;; material color yellow L100
     ))
 
-(provide-theme 'nano)
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path) load-file-name)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
 
- 
+(provide-theme 'nano)


### PR DESCRIPTION
Without this, load-theme would only be able to locate the theme if the
file happens to be located under `custom-theme-load-path`.

This is a common approach:

- [doom-themes](https://github.com/hlissner/emacs-doom-themes/blob/0819fa929bc2777432b86bca0f12fda3fff5da77/doom-themes.el#L423-L429)
- [spacemacs-theme](https://github.com/nashamri/spacemacs-theme/blob/c8c468580048e2464f012d171b2101bfb208e33d/spacemacs-common.el#L1034-L1037)
- [monokai-emacs](https://github.com/oneKelvinSmith/monokai-emacs/blob/c5a7978bfc2ad2aa90882e6b2583668dc7b3e1a5/monokai-theme.el#L6247-L6250)