### PR TITLE
Add file header

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Install with [straight.el](https://github.com/raxod502/straight.el):
                                    :repo "rougier/nano-theme"))
 ```
 
+... or install with [`quelpa`](https://github.com/quelpa/quelpa):
+
+```emacs-lisp
+(use-package nano-theme
+  :ensure nil
+  :defer t
+  :quelpa (nano-theme
+           :fetcher github
+           :repo "rougier/nano-theme"))
+```
+
 ### Usage
 
 Load theme directly: `M-x: (load-theme 'nano t)`  

--- a/nano-theme.el
+++ b/nano-theme.el
@@ -1,3 +1,5 @@
+;;; nano-theme.el --- A consistent theme for GNU Emacs  -*- coding: utf-8 -*-
+
 ;; ---------------------------------------------------------------------
 ;; GNU Emacs / N Λ N O theme
 ;; Copyright (C) 2021 - Nicolas P. Rougier


### PR DESCRIPTION
This allows the package to be installed with Quelpa:

```emacs-lisp
(use-package nano-theme
  :ensure nil
  :defer t
  :quelpa (nano-theme
           :fetcher github
           :repo "rougier/nano-theme"))
```

Without it the following error message is shown:

```
Error getting PACKAGE-DESC: (error Package lacks a file header)
quelpa-package-install: Wrong type argument: package-desc, nil
```