### PR TITLE
fix tool-bar-mode

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -355,7 +355,7 @@ background color that is barely perceptible."
 
   ;; No toolbar
   (if (fboundp 'tool-bar-mode)
-      (tool-bar-mode nil))
+      (tool-bar-mode -1))
 
   ;; Default frame settings
   (setq default-frame-alist


### PR DESCRIPTION
"If called from Lisp, toggle the mode if ARG is toggle.  Enable the
mode if ARG is nil, omitted, or is a positive number.  Disable the
mode if ARG is a negative number."