### PR TITLE
actually disable tool-bar mode

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -355,7 +355,7 @@ background color that is barely perceptible."
 
   ;; No toolbar
   (if (fboundp 'tool-bar-mode)
-      (tool-bar-mode nil))
+      (tool-bar-mode -1))
 
   ;; Default frame settings
   (setq default-frame-alist


### PR DESCRIPTION
For some reason calling (tool-bar-mode nil) actually toggles it on in my setup.
Is it specific to me ? I'm on emacs 28 built from source on macOS.