### PR TITLE
`nano-setup` should be made interactive

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -287,6 +287,7 @@ background color that is barely perceptible."
 
 (defun nano-setup ()
   "Defaults settings for nano (optional)"
+  (interactive)
 
   ;; Use nano fonts
   (setq nano-fonts-use t)


### PR DESCRIPTION
Nano-setup needs to be a command so that it can be called with `M-x nano-setup` as indicated in the README.