### PR TITLE
Sets `line-number-current-line` to `:inherint nil`

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -750,7 +750,7 @@ background color that is barely perceptible."
    
    ;; --- Line numbers -------------------------------------------------
    '(line-number                  ((t (:inherit nano-faded))))
-   '(line-number-current-line     ((t (:inherit default))))
+   '(line-number-current-line     ((t (:inherit nil))))
    `(line-number-major-tick       ((t (:inherit nano-faded))))
    '(line-number-minor-tick       ((t (:inherit nano-faded))))
    


### PR DESCRIPTION
In doom-emacs when you use the zen mode `SPC t z/Z`, the face for `line-number-current-line` is bigger than `line-number`.  

This commit fixes this behavior. 

Fixes #21.