### PR TITLE
Changes font for flyspell

### DIFF
--- a/nano-theme.el
+++ b/nano-theme.el
@@ -983,9 +983,9 @@ background color that is barely perceptible."
    '(outline-8                      ((t (:inherit nano-strong))))
    
    ;; --- Fly spell ----------------------------------------------------
-   '(flyspell-duplicate             ((t (:inherit (highlight nano-faded)
+   '(flyspell-duplicate             ((t (:inherit nano-popout
                                          :underline t))))
-   '(flyspell-incorrect             ((t (:inherit (highlight nano-faded)
+   '(flyspell-incorrect             ((t (:inherit nano-popout
                                          :underline t))))
 
    ;; --- Org agenda ---------------------------------------------------


### PR DESCRIPTION
The flyspell errors with `nano-faded` looked invisible for editing long texts. Changing them to `nano-popout` and removing the `highlight` makes them clearer into the text without distracting too much.

Before
![image](https://user-images.githubusercontent.com/4078489/171211734-f503b939-dce6-473d-bf0b-6b7f4481b18f.png)

After
![image](https://user-images.githubusercontent.com/4078489/171211541-f9f1e97c-4b82-4778-80c3-7fb61be35a20.png)
