### PR TITLE
Change to nano-salient the magit-keyword faces

### DIFF
--- a/nano-theme-support.el
+++ b/nano-theme-support.el
@@ -1425,8 +1425,8 @@ background color that is barely perceptible."
     '(magit-header-line-key                  ((t (:inherit nano-default))))
     '(magit-header-line-log-select           ((t (:inherit nano-default))))
 
-    '(magit-keyword                          ((t (:inherit nano-default))))
-    '(magit-keyword-squash                   ((t (:inherit nano-default))))
+    '(magit-keyword                          ((t (:inherit nano-salient))))
+    '(magit-keyword-squash                   ((t (:inherit nano-salient))))
 
     '(magit-log-author                       ((t (:inherit nano-default))))
     '(magit-log-date                         ((t (:inherit nano-default))))


### PR DESCRIPTION
With this change, we can distinguish better if there are keywords in the magit's commit log.

Compare this 

![image](https://user-images.githubusercontent.com/4078489/210840220-a0002a33-eb1c-42fa-b74b-5ddbffcb28fc.png)

with this 

![image](https://user-images.githubusercontent.com/4078489/210840293-c11fbcb7-a9a3-4fc5-8cee-d696497287db.png)


Best. 